### PR TITLE
F1 2022 was update to v1.10 with certain struct changes

### DIFF
--- a/src/include/2022/EventDataDetails.h
+++ b/src/include/2022/EventDataDetails.h
@@ -29,7 +29,7 @@ struct Penalty
     uint8 otherVehicleIdx;                      // Vehicle index of the other car involved
     uint8 time;                                 // Time gained, or time spent doing action in seconds
     uint8 lapNum;                               // Lap the penalty occurred on
-    uint8 placesGained;                         // Number of places gained by this
+    // uint8 placesGained;                         // Number of places gained by this
 };
 
 struct SpeedTrap

--- a/src/include/2022/PacketLapData.h
+++ b/src/include/2022/PacketLapData.h
@@ -5,5 +5,5 @@ struct PacketLapData
     struct LapData         m_lapData[22];         // Lap data for all cars on track
 
     uint8	m_timeTrialPBCarIdx; 	// Index of Personal Best car in time trial (255 if invalid)
-    uint8	m_timeTrialRivalCarIdx; 	// Index of Rival car in time trial (255 if invalid)
+    // uint8	m_timeTrialRivalCarIdx; 	// Index of Rival car in time trial (255 if invalid)
 };


### PR DESCRIPTION
The changes are for the 2022 version of the game:
- The `LapData` (lost one byte - from 972 to 971) - this happened in version 1.8 (of F1 2022). 
   Field `uint8 m_timeTrialRivalCarIdx` was removed.

- The `EventDetails` (lost one byte from 40 to 39) - this happened in version 1.9 (of F1 2022) and 1.10 came out but from what we've seen no changes from 1.9. 
   Field `uint8 placesGained` was removed as well.
